### PR TITLE
Handle a status of 0 when using the file protocol

### DIFF
--- a/licenses/CLA-INDIVIDUAL.md
+++ b/licenses/CLA-INDIVIDUAL.md
@@ -103,3 +103,4 @@ Felix Küppers, @felixhayashi, 2014-11-20
 Rich Rath @rcrath 2014-04-12  
 Cameron Fischer @flibbles 2016-01-19  
 Michael Ballantyne @michaelballantyne 2016-06-13
+Victor Ling @kasukoxr 2016-12-14

--- a/src/plugins/felixhayashi/tiddlymap/js/lib.utils.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/lib.utils.js
@@ -782,7 +782,7 @@ utils.getImgFromWeb = function(imgUri, callback) {
   xhr.responseType = "blob";
   xhr.onerror = function(e) { console.log(e); };
   xhr.onload = function(e) {
-    if(this.readyState === 4 && this.status === 200) {
+    if(this.readyState === 4 && (this.status===200 || (this.status === 0 && this.response.size > 0))) {
       var blob = this.response;
       callback(window.URL.createObjectURL(blob));
     }


### PR DESCRIPTION
When we allow cross-origin requests the XMLHttpRequest's status is 0 when using the file system protocol.

Allow updating the image if the response has data even if the status is 0.

This code isn't the cleanest, but it's the tersest I could come up with. Let me know how your code style dictates this should actually be done?

Note: This requires explicitly allowing cross-origin requests e.g. launching Google Chrome with the `--allow-file-access-from-files` flag. Testing with TiddlyDesktop, this works without change.

Closes #248 