### PR TITLE
Added insertEdge to FilterEdgeTypeSubscriber

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
@@ -53,6 +53,36 @@ class FilterEdgeTypeSubstriber extends AbstractMagicEdgeTypeSubscriber {
     return toRefs;
 
   }
+
+  /**
+   * Stores and maybe overrides an edge in this tiddler
+   */
+  insertEdge(tObj, edge, type) {
+
+    if (!edge.to) {
+      return;
+    }
+
+    // get the name without the private marker or the namespace
+    const name = type.name;
+    const currentFilter = tObj.fields[name] || "";
+    const toTRef = this.tracker.getTiddlerById(edge.to);
+    // by treating the toTRef as a list of one, we can make
+    // it safe to append to any filter.
+    // "tiddler" -> "tiddler"
+    // "tiddler with spaces" -> "[[tiddler with spaces]]"
+    var safe_toTRef = $tw.utils.stringifyList([toTRef]);
+
+    if (currentFilter.length > 0) {
+      safe_toTRef = " " + safe_toTRef;
+    }
+
+    // save
+    utils.setField(tObj, name, currentFilter + safe_toTRef);
+
+    return edge;
+
+  };
 }
 
 /*** Exports *******************************************************/


### PR DESCRIPTION
Since lists are within the set of filters, a tiddler can be arbitrarily added to a legal filter simply by appending to the end as though the filter were a list.

So when the user draws a new edge and specifies that it's for a filter edge type, there is an intuitive action that TiddlyMap can take. This feature is useful for people (like me) who will use filter edge types sometimes as a filter type and sometimes as a list type.

Code is tested. It's also pretty straight forward.