### PR TITLE
Minor fixes for v13.2 concerning edgeTypeSubscribers

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/AbstractMagicEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/AbstractMagicEdgeTypeSubscriber.js
@@ -44,14 +44,12 @@ class AbstractMagicEdgeTypeSubscriber extends AbstractRefEdgeTypeSubscriber {
    *
    * @interface
    * @param {Tiddler} tObj - the tiddler that holds the references.
+   * @param {String} fieldName - the name of the field to get the reference from.
    * @param {Object<TiddlerReference, boolean>} toWL - a whitelist of tiddlers that are allowed to
    *     be included in the result.
-   * @param {Object<id, EdgeType>} [typeWL] - a whitelist that defines that only Tiddlers that are linked
-   *     via a type specified in the list may be included in the result. If typeWL is not passed it means
-   *     all types are included.
    * @return {Object<Id, Edge>|null}
    */
-  getReferencesFromField(tObj, toWL, typeWL) {
+  getReferencesFromField(tObj, fieldName, toWL) {
 
     throw new MissingOverrideError(this, 'getReferencesFromField');
 

--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/AbstractRefEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/AbstractRefEdgeTypeSubscriber.js
@@ -84,7 +84,7 @@ class AbstractRefEdgeTypeSubscriber extends AbstractEdgeTypeSubscriber {
    */
   getReferences(tObj, toWL, typeWL) {
 
-    throw new MissingOverrideError(this, 'getReferencesFromField');
+    throw new MissingOverrideError(this, 'getReferences');
 
   }
 }

--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FieldEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FieldEdgeTypeSubscriber.js
@@ -52,7 +52,7 @@ class FieldEdgeTypeSubscriber extends AbstractMagicEdgeTypeSubscriber {
   /**
    * @override
    */
-  getReferencesFromField(tObj, fieldName) {
+  getReferencesFromField(tObj, fieldName, toWL) {
 
     // wrap in array
     return [ tObj.fields[fieldName] ];

--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
@@ -44,7 +44,7 @@ class FilterEdgeTypeSubstriber extends AbstractMagicEdgeTypeSubscriber {
   /**
    * @override
    */
-  getReferencesFromField(tObj, fieldName) {
+  getReferencesFromField(tObj, fieldName, toWL) {
 
     const filter = tObj.fields[fieldName];
     //noinspection UnnecessaryLocalVariableJS

--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/ListEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/ListEdgeTypeSubscriber.js
@@ -53,7 +53,7 @@ class ListEdgeTypeSubscriber extends AbstractMagicEdgeTypeSubscriber {
   /**
    * @override
    */
-  getReferencesFromField(tObj, fieldName) {
+  getReferencesFromField(tObj, fieldName, toWL) {
 
     return $tw.utils.parseStringArray(tObj.fields[fieldName]);
 

--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/refEdgeTypeSubscriber/TranscludeEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/refEdgeTypeSubscriber/TranscludeEdgeTypeSubscriber.js
@@ -35,7 +35,7 @@ class TranscludeEdgeTypeSubscriber extends AbstractRefEdgeTypeSubscriber {
    */
   canHandle(edgeType) {
 
-    return edgeType.id === 'tw-body:link';
+    return edgeType.id === 'tw-body:transclude';
 
   }
 


### PR DESCRIPTION
This fixes the following:

- `TranscludeEdgeTypeSubscriber#canHandle` comparison correction
- method signatures for `AbstractMagicEdgeTypeSubscriber#getReferencesFromField` are now consistent. Filter type no longer fails to interpret.
- string correction in the unimplemented `AbstractRefEdgeTypeSubscriber#getReferences`. It was an unimplemented exception specifying the wrong method name.