### PR TITLE
filter edge types can handle filters referencing <currentTiddler>

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
@@ -49,6 +49,7 @@ class FilterEdgeTypeSubstriber extends AbstractMagicEdgeTypeSubscriber {
 
     const filter = tObj.fields[fieldName];
 
+    // Solves https://github.com/felixhayashi/TW5-TiddlyMap/issues/278
     const parentWidget = new Widget.widget({});
     parentWidget.setVariable("currentTiddler", tObj.fields.title);
     const widget = new Widget.widget({}, {"parentWidget": parentWidget});

--- a/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/edgeTypeSubscriber/magicEdgeTypeSubscriber/FilterEdgeTypeSubscriber.js
@@ -13,6 +13,7 @@ module-type: tmap.edgetypehandler
 
 import utils from '$:/plugins/felixhayashi/tiddlymap/js/utils';
 import AbstractMagicEdgeTypeSubscriber from '$:/plugins/felixhayashi/tiddlymap/js/AbstractMagicEdgeTypeSubscriber';
+import Widget from "$:/core/modules/widgets/widget.js";
 
 /*** Code **********************************************************/
 
@@ -47,8 +48,12 @@ class FilterEdgeTypeSubstriber extends AbstractMagicEdgeTypeSubscriber {
   getReferencesFromField(tObj, fieldName, toWL) {
 
     const filter = tObj.fields[fieldName];
+
+    const parentWidget = new Widget.widget({});
+    parentWidget.setVariable("currentTiddler", tObj.fields.title);
+    const widget = new Widget.widget({}, {"parentWidget": parentWidget});
     //noinspection UnnecessaryLocalVariableJS
-    const toRefs = utils.getMatches(filter, toWL);
+    const toRefs = utils.getMatches(filter, toWL, widget);
 
     return toRefs;
 

--- a/src/plugins/felixhayashi/tiddlymap/js/lib/utils/wiki.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/lib/utils/wiki.js
@@ -209,7 +209,7 @@ export const moveFieldValues = (oldName, newName, isRemoveOldField, isIncludeSys
  *     selected. Shadows are *not* included.
  * @return {Array.<TiddlerReference>}
  */
-export const getMatches = (filter, tiddlers) => {
+export const getMatches = (filter, tiddlers, widget) => {
 
   // use wiki as default source
   let source = undefined;
@@ -237,7 +237,7 @@ export const getMatches = (filter, tiddlers) => {
 
   }
 
-  return filter.call(wiki, source);
+  return filter.call(wiki, source, widget);
 
 };
 


### PR DESCRIPTION
Here is the solution along with the requested comment.

I think I probably will file an issue with Tiddlywiki about __Widget##getVariable__. This isn't the first time I've looked at _the exact line you referenced_ and wondered why it was written that way. If someone else feels it's a bug, then it may actually be one.