### PR TITLE
View##addNode doesn't change filter if unneeded

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/graph/ViewAbstraction.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/graph/ViewAbstraction.js
@@ -468,11 +468,17 @@ class ViewAbstraction {
 
     if (!this._isNodeIncludedById(node)) {
 
-      const part = ViewAbstraction._getNodeIdFilterPart(node);
-      const separator = ' ';
-      this.setNodeFilter(this.getNodeFilter('raw') + separator + part);
+      // @see https://github.com/felixhayashi/TW5-TiddlyMap/issues/285
+      if (utils.isTrue($tm.config.sys.alwaysAddNodeIdToViewFilter) || this.getNodeFilter('compiled')().indexOf(node.label) == -1) {
+
+        const part = ViewAbstraction._getNodeIdFilterPart(node);
+        const separator = ' ';
+        this.setNodeFilter(this.getNodeFilter('raw') + separator + part);
+
+      }
 
       this.saveNodePosition(node);
+
     }
 
   }

--- a/src/plugins/felixhayashi/tiddlymap/js/lib/environment.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/lib/environment.js
@@ -83,6 +83,7 @@ export const config = {
       height: '140px'
     },
     jsonIndentation: '1',
+    alwaysAddNodeIdToViewFilter: 'true',
     editNodeOnCreate: 'false',
     singleClickMode: 'false',
     editorMenuBar: {


### PR DESCRIPTION
This behavior can be enabled by setting
'config.sys.alwaysAddNodeIdToViewFilter' to 'false'