### PR TITLE
Utilizing tiddlywiki caching

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
@@ -581,7 +581,7 @@ class MapWidget extends Widget {
     } else { // view has not been switched
 
       // give the view a chance to refresh itself
-      const isViewUpdated = this.view.update(updates);
+      const isViewUpdated = this.view.hasUpdated(updates);
 
       if (isViewUpdated) {
 
@@ -1931,8 +1931,10 @@ class MapWidget extends Widget {
 
     const viewLabel = this.view.getLabel();
 
-    // we do not used the cashed version since we need a new object!
-    const nodeData = this.view.getNodeData(node.id, true) || {};
+    // we copy the object since we intend to modify it.
+    // NOTE: A deep copy would be needed if a nested property were modified
+    //       In that case, use $tw.utils.deepCopy.
+    const nodeData = { ...this.view.getNodeData(node.id) };
     // we need to delete the positions so they are not reset when a user
     // resets the style…
     delete nodeData.x;


### PR DESCRIPTION
By utilizing tiddlywiki's inbuilt caching mechanism, it spares the ViewAbstraction from having to manage one itself. Hopefully, but letting Tiddlywiki manage each individual view tiddler on its own, it can reduce the amount of refreshing.

I'm currently using TiddlyMap on my machine with these changes active. I haven't encountered any problems, but I'm still only submitting this PR at this time with intent for review.

This is my proposal for #286

Comments are among the changes.