### PR TITLE
Changed DarkSlateGray to darkslategray for vis support

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_list_tags.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_list_tags.tid
@@ -1,4 +1,4 @@
 title: $:/plugins/felixhayashi/tiddlymap/graph/edgeTypes/tw-list:tags
 description: A tag that refers to a tiddler of the same name.
-style: { "color": "DarkSlateGray", "dashes":true}
+style: { "color": "darkslategray", "dashes":true}
 label: tagged with


### PR DESCRIPTION
Attempting to edit the colors of the builtin list:tags edge type results in an exception being thrown. That's because Vis doesn't recognize `DarkSlateGray`. There is `darkslategray` though...