### PR TITLE
Corrected Firefox scroll issue when zooming (#306)

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
@@ -117,6 +117,8 @@ class MapWidget extends Widget {
       'mousewheel': [ this.handleCanvasScroll, true ],
       'DOMMouseScroll': [ this.handleCanvasScroll, true ],
       'contextmenu': [ this.handleContextMenu, true ],
+      // Solves: https://github.com/felixhayashi/TW5-TiddlyMap/issues/306
+      'MozMousePixelScroll': [ this.handleExtraCanvasScroll, true ],
     };
 
     this.widgetDomListeners = {
@@ -1077,6 +1079,15 @@ class MapWidget extends Widget {
       return false;
     }
 
+  }
+
+  /**
+   * This handles the extraneous event fired by Firefox whenever a
+   * DOMMouseScroll event occurs. We just want to swallow it.
+   * Solves: https://github.com/felixhayashi/TW5-TiddlyMap/issues/306
+   */
+  handleExtraCanvasScroll(ev) {
+    ev.preventDefault();
   }
 
   /**


### PR DESCRIPTION
This alteration allows the map frame to properly swallow the
MozMousePixelScroll event which is issued by Firefox, thus preventing
undesirable scrolling when zooming in the graph.