### PR TITLE
Add hotkey cmd/alt + num to change neighbourhood_scope

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
@@ -978,9 +978,18 @@ class MapWidget extends Widget {
 
   handleCanvasKeydown(ev) {
 
-    if (ev.keyCode === 46) { // delete
+    if (ev.altKey || ev.metaKey) {
       ev.preventDefault();
-      this.handleRemoveElements(this.network.getSelection());
+
+      if (ev.keyCode >= 48 && ev.keyCode <= 57) { // 0 through 9
+        const scopeStr = String.fromCharCode(ev.keyCode);
+        this.view.setConfig('neighbourhood_scope', scopeStr);
+      }
+    } else {
+      if (ev.keyCode === 46) { // delete
+        ev.preventDefault();
+        this.handleRemoveElements(this.network.getSelection());
+      }
     }
 
   }


### PR DESCRIPTION
# Feature
Add a hotkey for user to quickly change neighbourhood_scope
# Motivation
I use the live view to view all tiddlers related to my current tiddler via tags. I added this hotkey for myself so that I can quickly change the neighbourhood_scope in order to expand / contract the degree of separation of related nodes. Adding PR in case it's useful for others.

*If we think we want to merge this I'm happy to sign contributor docs listed in README* 😁
# Example 
To quickly expand related topics outward for the following views, I press:
## Cmd + 0
![image](https://user-images.githubusercontent.com/1871299/57576726-dc459f00-741b-11e9-977c-5f2942c5a912.png)
## Cmd + 1
![image](https://user-images.githubusercontent.com/1871299/57576728-e2d41680-741b-11e9-8f2c-07d184025a71.png)
## Cmd + 2
![image](https://user-images.githubusercontent.com/1871299/57576730-eebfd880-741b-11e9-9531-ae9feff64489.png)
