### PR TITLE
Tiddlymap acknowledges timestamp settings (#316)

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/lib/utils/wiki.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/lib/utils/wiki.js
@@ -767,6 +767,12 @@ export const addTiddler = (tiddler, isForce) => {
 
 };
 
-export const touch = tRef => {
-  setField(tRef, 'modified', new Date());
+export const touch = tiddler => {
+  if (!tiddler) {
+    return;
+  }
+  let tObj = $tw.wiki.getTiddler(tiddler);
+  tObj = new $tw.Tiddler(tObj, $tw.wiki.getModificationFields());
+
+  $tw.wiki.addTiddler(tObj);
 };

--- a/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/widget/MapWidget.js
@@ -1529,9 +1529,9 @@ class MapWidget extends Widget {
     $tw.wiki.addTiddler(new $tw.Tiddler({
       title: tRef,
       type: 'image/png',
-      text: this.getSnapshot(true),
-      modified: new Date()
-    }));
+      text: this.getSnapshot(true)
+    }, $tw.wiki.getCreationFields(),
+       $tw.wiki.getModificationFields()));
 
     return tRef;
 


### PR DESCRIPTION
Changed the `touch` method in wiki utils. And tested it.

Also, modified the createAndSaveSnapshot method in the MapWidget, but I did **not** test this, because I couldn't figure out how.