### PR TITLE
Set tmap.id to be invisible

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/misc/misc.config.edit_template_fields_visibility.multids
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/misc/misc.config.edit_template_fields_visibility.multids
@@ -1,0 +1,3 @@
+title: $:/config/EditTemplateFields/Visibility/
+
+tmap.id: hide


### PR DESCRIPTION
I propose making the tmap.id field hidden. It's ugly. And it's on every single tiddler.

I've used Tiddlymap for years now. I've never had cause to modify tmap.id, and doing so would probably cause problems.

The only time tmap.id even comes up is after I clone a tiddler. Then Tiddlymap pops up a complaint about duplicate tmap.ids, but I've always just hit the okay button, and it seems fine. But then, I also only use magic edge types.

Thoughts?