### PR TITLE
Fixed #327: duplicates in node filter crashes

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/js/lib/utils/tmap.js
+++ b/src/plugins/felixhayashi/tiddlymap/js/lib/utils/tmap.js
@@ -469,8 +469,12 @@ export const getLookupTable = (col, lookupKey) => {
       }
     }
 
-    // @todo use exception class
-    throw new Error(`Cannot use "${idx}" as lookup table index`);
+    // only throw if lookupKey is set to avoid crash if duplicates exist in col
+    // Solves: https://github.com/felixhayashi/TW5-TiddlyMap/issues/327
+    if (lookupKey) {
+      // @todo use exception class
+      throw new Error(`Cannot use "${idx}" as lookup table index`);
+    }
 
   }
 


### PR DESCRIPTION
Added check so exception is only thrown if getLookupTable is crafting
a table based on a specific field.