### PR TITLE
Hack: make importvariables force refresh

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.tid
@@ -5,7 +5,8 @@ title: $:/plugins/felixhayashi/tiddlymap/dialog
 <div class=<<classes>>>
 <$importvariables
     filter="[[$:/plugins/felixhayashi/tiddlymap/misc/macros]]
-            [[$:/core/macros/tabs]]">
+            [[$:/core/macros/tabs]]
+            [<currentTiddler>removesuffix[/output]]">
 <$transclude tiddler=<<template>> mode="block" />
 </$importvariables>
 </div>


### PR DESCRIPTION
Fix for #407

This forces the importvariables widget containing all dialogs to refresh if the underlying generated tiddler changes. Not a great fix, but it works. Hopefully there is a better one.