### PR TITLE
Fixed edge colors for Vis v4.21.0

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tmap_unknown.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tmap_unknown.tid
@@ -1,4 +1,4 @@
 title: $:/plugins/felixhayashi/tiddlymap/graph/edgeTypes/tmap:unknown
 description: Automatically assigned to an edge that does not have a type assigned
-style: {"color":"gray"}
+style: {"color":{"color":"gray"}}
 show-label: false

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_body_link.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_body_link.tid
@@ -1,5 +1,5 @@
 title: $:/plugins/felixhayashi/tiddlymap/graph/edgeTypes/tw-body:link
 description: A link that is contained in the tiddler's body pointing to another resource.
-style: {"color":"orange", "dashes":true}
+style: {"color":{"color":"orange"}, "dashes":true}
 label: links to
 

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_list_list.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_list_list.tid
@@ -1,5 +1,5 @@
 title: $:/plugins/felixhayashi/tiddlymap/graph/edgeTypes/tw-list:list
 description: Contained in a list of this tiddler
-style: { "color": "red", "dashes":true}
+style: { "color":{"color":"red"}, "dashes":true}
 label: listed in
 

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_list_tags.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/edgetypes/edgetype.tw_list_tags.tid
@@ -1,4 +1,4 @@
 title: $:/plugins/felixhayashi/tiddlymap/graph/edgeTypes/tw-list:tags
 description: A tag that refers to a tiddler of the same name.
-style: { "color": "darkslategray", "dashes":true}
+style: { "color":{"color":"darkslategray"}, "dashes":true}
 label: tagged with


### PR DESCRIPTION
The upgraded Vis V4.21.0 is more strict about the JSON describing an edge's color. As such, all of the default edge colors in TiddlyMap were improperly described and come out as a default gray.

This fixes that.