### PR TITLE
Whitespace trim pragma

### DIFF
--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.default.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.default.tid
@@ -1,10 +1,15 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig/default
 caption: Overview
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-flash-message tmap-plain">
-  Please visit the [[online docs|http://tiddlymap.org/Documentation]]
+  &#32;
+  Please visit the
+  &#32;
+  [[online docs|http://tiddlymap.org/Documentation]]
+  &#32;
   for more information about the available global options.
 </div>
 <table class="tmap-key-value-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.editor.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.editor.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig/editor
 caption: Editor
 
+\whitespace trim
 \rules except wikilink
 
 <table class="tmap-config-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.fields.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.fields.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig/fields
 caption: Field settings
 
+\whitespace trim
 \rules except wikilink
 
 <table class="tmap-config-table">
@@ -18,4 +19,3 @@ caption: Field settings
       descr:"Field used as tooltip when hovering over a node in a graph."
       note:"It is prohibited to use the text field here.">>
 </table>   
-

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.interaction.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.interaction.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig/interaction
 caption: Interaction & behaviour
 
+\whitespace trim
 \rules except wikilink
 
 <table class="tmap-config-table">
@@ -26,13 +27,13 @@ caption: Interaction & behaviour
       title:"Popup width"
       field:"config.sys.popups.width"
       descr:"The default max-width of the popup."
-      note:"Make sure you added the desired unit (e.g. `px`).
+      note:"Make sure you added the desired unit (e.g.&#32;`px`).
             Requires a wiki refresh.">>
   <<tmap-row type:"input-text"
       title:"Popup height"
       field:"config.sys.popups.height"
       descr:"The default max-height of the popup."
-      note:"Make sure you added desired the unit (e.g.  `px`).
+      note:"Make sure you added desired the unit (e.g.&#32;`px`).
             Requires a wiki refresh.">>
   </$list>
   <<tmap-row type:"input-checkbox"
@@ -64,6 +65,7 @@ caption: Interaction & behaviour
 !! Suppressed dialogs
 
 <div class="tmap-flash-message tmap-plain">
+  &#32;
   Dialogs that you decided to suppress in the past are listed here.
   Remove the checkmark to enable dialogs again.
 </div>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.live_tab.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.live_tab.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig/liveTab
 caption: Live tab
 
+\whitespace trim
 \rules except wikilink
 
 <table class="tmap-config-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.tid
@@ -2,6 +2,7 @@ title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig
 subtitle: {{$:/core/images/options-button}} Global configuration of TiddlyMap
 classes: tmap-remove-top-space
 
+\whitespace trim
 \rules except wikilink
 
 <$macrocall $name="tabs"

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.verbosity.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.verbosity.tid
@@ -1,9 +1,11 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig/verbosity
 caption: Verbosity
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-flash-message tmap-plain">
+  &#32;
   Here you can restrict the system's talkativeness.
 </div>
 

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.vis.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_tiddlymap/dialog.configure_tiddlymap.vis.tid
@@ -2,15 +2,19 @@ title: $:/plugins/felixhayashi/tiddlymap/dialog/globalConfig/vis
 classes: tmap-remove-top-space
 caption: Graph
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-flash-message tmap-info">
+  &#32;
   The global vis configurations will affect all views and their
   elements (nodes and edges) unless they are overridden on a lower
   level. All options below are documented at
+  &#32;
   [[vis.js.org|http://visjs.org/docs/network]].
 </div>
 <div class="tmap-flash-message tmap-info">
+  &#32;
   Only config items that you actually changed have an effect on
   the graph. Other options are visible, yet, inactive.
 </div>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.default.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.default.tid
@@ -1,10 +1,12 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/configureView/default
 caption: Overview
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-flash-message tmap-info">
-   All configurations __only__ affect this view.
+   &#32;
+   All configurations&#32;__only__&#32;affect this view.
 </div>
 
 <table class="tmap-key-value-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.edit_filters.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.edit_filters.tid
@@ -1,16 +1,20 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/configureView/editFilters
 caption: Edit filters
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-flash-message tmap-info">
+  &#32;
   Completely new to filters? Please read
+  &#32;
   [[Introduction to filter notation|http://tiddlywiki.com/#Introduction%20to%20filter%20notation]]
+  &#32;
   first.
 </div>
 
 <fieldset>
-  <legend>Filters <sup>[1]</sup></legend>
+  <legend>Filters&#32;<sup>[1]</sup></legend>
   <table class="tmap-config-table tmap-large-input">
     <<tmap-row type:"input-textarea"
         title:"Node filter"
@@ -27,8 +31,13 @@ caption: Edit filters
 
 ---
 
-<sup>[1]</sup> In the editors above, a new line is equivalent to a space symbol.<br />
-<sup>[2]</sup> It is suggested to read
+<sup>[1]</sup>&#32;In the editors above, a new line is equivalent to a space symbol.<br />
+<sup>[2]</sup>&#32;It is suggested to read
+&#32;
 [[Node and edge-type filters|http://tiddlymap.org#Node%20and%20edge-type%20filters]]
-and [[Edge-type namespaces|http://tiddlymap.org#Node%20and%20edge-type%20filters]]
+&#32;
+and
+&#32;
+[[Edge-type namespaces|http://tiddlymap.org#Node%20and%20edge-type%20filters]]
+&#32;
 before using Tiddlymap's filter editor.

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.layout.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.layout.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/configureView/layout
 caption: Layout
 
+\whitespace trim
 \rules except wikilink
 
 <table class="tmap-config-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.namespace.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.namespace.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/configureView/namespace
 caption: Namespace
 
+\whitespace trim
 \rules except wikilink
 
 <table class="tmap-config-table tmap-small-input">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/configureView
 subtitle: {{$:/core/images/options-button}} View configuration -- <<view>>
 
+\whitespace trim
 \rules except wikilink
 
 \define privateEdgeTypes() [[private edge-types|http://tiddlymap.org/#Private%20edge%20types]]

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.vis.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/configure_view/dialog.configure_view.vis.tid
@@ -1,15 +1,19 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/configureView/vis
 caption: Graph
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-flash-message tmap-info">
+   &#32;
    The local vis configurations will affect all
    elements (nodes and edges) of this view, unless they are
    overridden on a lower level. All options below are documented at
+   &#32;
    [[vis.js.org|http://visjs.org/docs/network]].
 </div>
 <div class="tmap-flash-message tmap-info">
+  &#32;
   Only config items that you actually changed have an effect on the
   graph. Other options are visible, yet, inactive.
 </div>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.add_edge.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.add_edge.tid
@@ -11,6 +11,7 @@ subtitle: {{$:/plugins/felixhayashi/tiddlymap/icon}} Edge type specification
 \end
 
 \define badges()
+\whitespace trim
 <$tiddler tiddler={{!!text}}>
 <$set name="id" value=<<tmap "getETyId" "$(view)$">>>
 <$set name="isVisible" value=<<tmap "isETyVisible" "$(view)$">>>
@@ -21,16 +22,20 @@ subtitle: {{$:/plugins/felixhayashi/tiddlymap/icon}} Edge type specification
   <<id>>
   </span>
   <$list filter="[<isVisible>regexp[true]]">
+    &#32;
     <<badge "green" "visible" "Matches your view's filter">>
   </$list>
   <$list filter="[<isVisible>regexp[false]]">
+    &#32;
     <<badge "red" "not visible" "Doesn't match your view's filter">>
   </$list>
   <$list filter="[<id>!regexp[^tmap:unknown$]]" variable="item">
     <$list filter="[<id>regexp[^_]]">
+      &#32;
       <<badge "purple" "private" "Not shown in other views per default">>
     </$list>
     <$list filter="[<id>regexp[.+:.+]]">
+      &#32;
       <<badge "orange" "namespace" "This type is prefixed with a proper namespace">>
     </$list>
   </$list>
@@ -41,6 +46,7 @@ subtitle: {{$:/plugins/felixhayashi/tiddlymap/icon}} Edge type specification
 \end
 
 \define search()
+\whitespace trim
 <p>
   You are about to connect "<$text text="$(fromLabel)$" />"
   with "<$text text="$(toLabel)$" />". Please specify a type.

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.add_node.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.add_node.tid
@@ -2,14 +2,16 @@ title: $:/plugins/felixhayashi/tiddlymap/dialog/addNodeToMap
 subtitle: {{$:/core/images/tag-button}} Add node
 classes: tmap-modal-add-node
 
+\whitespace trim
 \rules except wikilink
 
 \define backButtonText() back to list
 \define outputAndTemplate() [[$(output)$]] [[$(template)$]]
 
 \define editor()
+\whitespace trim
   <$button class="tmap-go-back tc-btn-invisible">
-    {{$:/core/images/chevron-left}} <<backButtonText>>
+    {{$:/core/images/chevron-left}}&#32;<<backButtonText>>
     <$action-deletefield $tiddler=<<temp>> more template />
     <$action-sendmessage
         $message="tmap:tm-clear-tiddler"
@@ -19,6 +21,7 @@ classes: tmap-modal-add-node
 
   <$list filter="[<output>get[draft.title]is[tiddler]]">
   <div class="tmap-flash-message tmap-warning">
+   &#32;
    Tiddler already exists! Use another title or click
    "<<backButtonText>>" to cancel your edit.
   </div>
@@ -63,6 +66,7 @@ classes: tmap-modal-add-node
 \end
 
 \define search()
+\whitespace trim
 <p>Add an existing tiddler to the map or create a new one.</p>
 <table id="tmap-search-table">
   <tr>
@@ -84,7 +88,7 @@ classes: tmap-modal-add-node
                    before it is added to the map">
         {{$:/core/images/edit-button}}
         <$action-setfield $tiddler=<<temp>> more="true" />
-      </$button> <sup>[1]</sup>
+      </$button>&#32;<sup>[1]</sup>
       </$list>
     </td>
   </tr>
@@ -110,6 +114,7 @@ classes: tmap-modal-add-node
 <$list filter="[<output>get[draft.title]!is[tiddler]]">
 <hr />
 <sup>[1]</sup>
+&#32;
 <small>
   The tiddler does not exist yet and you may edit it
   before it is added to the map

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.cannot_delete_view.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.cannot_delete_view.tid
@@ -2,9 +2,10 @@ title: $:/plugins/felixhayashi/tiddlymap/dialog/cannotDeleteViewDialog
 subtitle: {{$:/core/images/locked-padlock}} You cannot delete this view!
 buttons: ok
 
+\whitespace trim
 \rules except wikilink
 
-It is not possible to delete the current view as ''<<count>>'' tiddlers
+It is not possible to delete the current view as&#32;''<<count>>''&#32;tiddlers
 are referencing it. To delete the view you must first remove the tiddlymap
 widgets in the tiddlers listed below or change their view attributes.
 

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.create_view.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.create_view.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/createView
 subtitle: {{$:/core/images/new-button}} Creating a new view
 
+\whitespace trim
 \rules except wikilink
 
 <table class="tmap-config-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.delete_node.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.delete_node.tid
@@ -1,15 +1,16 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/deleteNodeDialog
 subtitle: {{$:/core/images/delete-button}} You are about to delete <<count>> nodes
 
+\whitespace trim
 \rules except wikilink
 
 ''Please choose an option or abort:''
 
 <$radio tiddler=<<output>> field="delete-from" value="system">
-  Delete nodes from system <sup>[1]</sup>
+  Delete nodes from system&#32;<sup>[1]</sup>
 </$radio><br />
 <$radio tiddler=<<output>> field="delete-from" value="filter">
-  Delete nodes from graph's filter <sup>[2]</sup>
+  Delete nodes from graph's filter&#32;<sup>[2]</sup>
 </$radio>
 
 The following nodes will be deleted:
@@ -23,6 +24,8 @@ The following nodes will be deleted:
 ---
 
 <sup>[1]</sup>
+&#32;
 <small>This will delete all nodes, their corresponding tiddlers and all connected edges.</small><br/>
 <sup>[2]</sup>
-<small>''Important:'' Removing a node from the graph's filter only works, if the node has been added in the map editor per double click or via "Add Node". If the node hasn't been added as mentioned above, you need to change the underlying tiddler in a way that it doesn't match your filter anymore, if you don't want it to be displayed in the graph.</small>
+&#32;
+<small>''Important:''&#32;Removing a node from the graph's filter only works, if the node has been added in the map editor per double click or via "Add Node". If the node hasn't been added as mentioned above, you need to change the underlying tiddler in a way that it doesn't match your filter anymore, if you don't want it to be displayed in the graph.</small>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.dublicateId.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.dublicateId.tid
@@ -2,6 +2,7 @@ title: $:/plugins/felixhayashi/tiddlymap/dialog/dublicateIdInfo
 subtitle: {{$:/core/images/info-button}} Dublicate id detected
 buttons: ok_suppress
 
+\whitespace trim
 \rules except wikilink
 
 TiddlyMap requires the value of the id field ("tmap.id") to be

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edge_not_visible.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edge_not_visible.tid
@@ -2,10 +2,13 @@ title: $:/plugins/felixhayashi/tiddlymap/dialog/edgeNotVisible
 subtitle: {{$:/core/images/info-button}} Edge will not be visible in view "<<view>>"
 buttons: ok_suppress
 
+\whitespace trim
 \rules except wikilink
 
 You just created an edge of type
-<code><$text text=<<type>> /></code> that will not be
+&#32;
+<code><$text text=<<type>> /></code>
+&#32;that will not be
 visible in this view because it doesn't match your
 edge-type filter settings.
 
@@ -21,6 +24,7 @@ Some suggestions:
 <ul>
   <li>
     Explicitly add the type to the filter:
+    &#32;
     <code><$text text="[[" /><$text text=<<type>> /><$text text="]]" /></code>
   </li>
   <li>
@@ -29,11 +33,12 @@ Some suggestions:
       name="prefix"
       emptyValue=<<tmap halfOfString "$(type)$">>>
   Add a filter rule (e.g. a prefix filter) that will match
-  your type: <code>[prefix[<<prefix>>]]</code>
+  your type:&#32;<code>[prefix[<<prefix>>]]</code>
   </$set>
   </li>
   <li>Make your current view-filter less restrictive.</li>
 </ul>
 
 For further information, please see:
+&#32;
 [[Node and edge-type filters|http://tiddlymap.org#Node%20and%20edge-type%20filters]].

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edit_node.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edit_node.tid
@@ -5,8 +5,10 @@ classes: tmap-remove-top-space
 \rules except wikilink
 
 \define maybeShowTidColorWarning()
+\whitespace trim
   <$list filter="[<tidColor>regexp[.+]]">
   <div class="tmap-flash-message tmap-warning">
+    &#32;
     You have set the tiddler's color
     field to "<<tidColor>>". This value will be completely ignored
     when you change node's color properties in the vis editor below.
@@ -15,6 +17,7 @@ classes: tmap-remove-top-space
 \end
 
 \define iconSettings(twIconField, faIconField)
+\whitespace trim
   <fieldset>
     <legend>Icon Settings</legend>
     <table class="tmap-config-table">
@@ -33,6 +36,7 @@ classes: tmap-remove-top-space
 \end
 
 \define sharedSettings(twIconField, faIconField, labelField)
+\whitespace trim
   <fieldset>
     <legend>General Settings</legend>
     <table class="tmap-config-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edit_tiddler.draft.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edit_tiddler.draft.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/fullscreenTiddlerEditor/draft
 caption: Draft
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-modal-editor">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edit_tiddler.original.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.edit_tiddler.original.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/fullscreenTiddlerEditor/original
 caption: Current Version
 
+\whitespace trim
 \rules except wikilink
 
 <div class="tmap-modal-editor">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.saveCanvas.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.saveCanvas.tid
@@ -1,9 +1,11 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/saveCanvas
 subtitle: {{$:/core/images/options-button}} Save a snapshot image of view "<<view>>"
 
+\whitespace trim
 \rules except wikilink
 
 \define preview()
+\whitespace trim
 <div class="tmap-save-canvas-preview">
   <$transclude tiddler=<<snapshot>> /><br />
 </div>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/dialog.tid
@@ -1,5 +1,6 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog
 
+\whitespace trim
 \rules except wikilink
 
 <div class=<<classes>>>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.close.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.close.tid
@@ -1,5 +1,6 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialogFooter/close
 
+\whitespace trim
 \rules except wikilink
 
 <$button class="tmap-dialog-button tmap-close-button" tooltip="Close this dialog">Close

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.ok.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.ok.tid
@@ -1,5 +1,6 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialogFooter/ok
 
+\whitespace trim
 \rules except wikilink
 
 <$button class="tmap-dialog-button tmap-ok-button" tooltip="Confirm dialog">OK

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.ok_cancel.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.ok_cancel.tid
@@ -1,8 +1,10 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialogFooter/ok_cancel
 
+\whitespace trim
 \rules except wikilink
 
 <$transclude tiddler="$:/plugins/felixhayashi/tiddlymap/dialogFooter/ok" mode="inline" />
+&#32;
 <$button class="tmap-dialog-button tmap-cancel-button" tooltip="Close dialog without saving">Cancel
   <!-- trigger dialog callback -->
   <$action-setfield $tiddler=<<result>> text="" />

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.ok_suppress.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.ok_suppress.tid
@@ -1,10 +1,12 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialogFooter/ok_suppress
 
+\whitespace trim
 \rules except wikilink
 
 <$set name="currentTiddler" value=<<title>> >
 
 <$checkbox field="suppress" checked="1" unchecked="0" default="0"> Do not show this dialog again</$checkbox>
+&#32;
 <$button class="tmap-dialog-button tmap-ok-button" tooltip="Confirm this dialog">OK
 
   <!-- trigger dialog callback -->

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.tid
@@ -1,5 +1,6 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialogFooter
 
+\whitespace trim
 \rules except wikilink
 
 \define footer() $:/plugins/felixhayashi/tiddlymap/dialogFooter/$(buttons)$

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.type_manager.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/footers/dialog_footer.type_manager.tid
@@ -1,5 +1,6 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialogFooter/element_type_manager
 
+\whitespace trim
 \rules except wikilink
 
 <$button
@@ -10,6 +11,7 @@ title: $:/plugins/felixhayashi/tiddlymap/dialogFooter/element_type_manager
       mode=<<mode>>
       output=<<output>> />
 </$button>
+&#32;
 <$button
     class="tmap-dialog-button tmap-cancel-button"
     tooltip="Cancel the most resent changes and exit">Quit

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.danger_settings.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.danger_settings.tid
@@ -1,10 +1,11 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/MapElementTypeManager/deleteType
 caption: Removal
 
+\whitespace trim
 \rules except wikilink
 
 \define manage-edge-types()
-  <$macrocall $name="tmap-row"
+<$macrocall $name="tmap-row"
       type="input-checkbox"
       title="Delete type"
       field="temp.deleteType"
@@ -17,7 +18,7 @@ caption: Removal
 \end
 
 \define manage-node-types()
-  <$macrocall $name="tmap-row"
+<$macrocall $name="tmap-row"
       type="input-checkbox"
       title="Delete type"
       field="temp.deleteType"

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.description.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.description.tid
@@ -1,10 +1,11 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/MapElementTypeManager/description
 caption: Description
 
+\whitespace trim
 \rules except wikilink
 
 \define manage-edge-types()
-  <<tmap-row type:"input-textarea"
+<<tmap-row type:"input-textarea"
       title:"Description"
       field:"description"
       descr:"An optional description for this type. The
@@ -13,7 +14,7 @@ caption: Description
 \end
 
 \define manage-node-types()
-  <<tmap-row type:"input-textarea"
+<<tmap-row type:"input-textarea"
       title:"Description"
       field:"description" 
       descr:"An optional description for this type.">>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.general_settings.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.general_settings.tid
@@ -1,9 +1,11 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/MapElementTypeManager/generalSettings
 caption: General
 
+\whitespace trim
 \rules except wikilink
 
 \define manage-edge-types()
+\whitespace trim
   <<tmap-row type:"input-text"
       title:"Label"
       field:"label"
@@ -15,6 +17,7 @@ caption: General
       descr:"If unchecked, no edge label will be displayed.">>
 \end
 \define manage-node-types()
+\whitespace trim
   <$list filter="[<currentTiddler>!regexp:id[tmap:]]">
   <<tmap-row type:"input-textarea"
       title:"Scope"

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.overview.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.overview.tid
@@ -1,6 +1,7 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/MapElementTypeManager/overview
 caption: Overview
 
+\whitespace trim
 \rules except wikilink
 
 \define date(f) <$view field=$f$ format="date" template="DDth mmm hh:mm:ss"/>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.styling.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.styling.tid
@@ -1,9 +1,11 @@
 title: $:/plugins/felixhayashi/tiddlymap/dialog/MapElementTypeManager/styling
 caption: Styling
 
+\whitespace trim
 \rules except wikilink
 
 \define url()
+\whitespace trim
   <$set
       filter="[<mode>prefix[manage-edge-types]]"
       name="module"
@@ -31,9 +33,11 @@ caption: Styling
 
 <fieldset><legend>Visjs styles</legend>
   <div class="tmap-flash-message tmap-info">
-     All visjs options below are documented at <<url>>.
+     &#32;
+     All visjs options below are documented at&#32;<<url>>.
   </div>
   <div class="tmap-flash-message tmap-info">
+     &#32;
      Only config items that you actually changed have an effect on
      the graph. Other options are visible, yet, inactive.
   </div>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/dialog/type_manager/dialog.type_manager.tid
@@ -3,6 +3,7 @@ subtitle: {{$:/core/images/tag-button}} <<topic>>
 buttons: element_type_manager
 classes: tmap-remove-top-space
 
+\whitespace trim
 \rules except wikilink
 
 \define defaultTab()
@@ -37,6 +38,7 @@ $(searchSelector)$
           type="text"
           tag="input"
           default="" />
+      &#32;
       <$list filter="[{$:/temp/tmap/MapElementTypeSearch}regexp[.+]]
                      +[addprefix[/]]
                      +[addprefix<typeRootPath>]
@@ -60,8 +62,9 @@ $(searchSelector)$
           variable="id">
       <li>
         <span class="tmap-ranking tmap-node-type-specific">
-          # <$view tiddler=<<typePath>> field="priority">1</$view>
+          #&#32;<$view tiddler=<<typePath>> field="priority">1</$view>
         </span>
+        &#32;
         <$button class="tc-btn-invisible tmap-link"><<id>>
           <$action-setfield
               $tiddler=<<qualify "$:/state/tabs/MapElementTypeManager">>
@@ -86,10 +89,12 @@ $(searchSelector)$
     </$reveal>
     <$reveal type="match" text="" default={{!!id}} >
       <div class="tmap-flash-message tmap-info">
+        &#32;
         Please select a type from the list or create a new one by
         entering the type name in the search field on the left.
       </div>
       <div class="tmap-flash-message tmap-info tmap-node-type-specific">
+        &#32;
         The number next to the node-type label represents it's priority.
       </div>
     </$reveal>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/context_menu.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/context_menu.tid
@@ -1,27 +1,33 @@
 title: $:/plugins/felixhayashi/tiddlymap/editor/contextMenu/node
 
 \define single()
+\whitespace trim
   <$list filter="
       [[tmap:tm-toggle-central-topic, $:/core/images/star-filled, Toggle central topic]]
       [[tmap:tm-delete-element, $:/core/images/delete-button, Delete node]]">
     <$button class="tc-btn-invisible">
       <$action-sendmessage $message=<<tmap "splitAndSelect" ", " "0">> />
       <$transclude tiddler=<<tmap "splitAndSelect" ", " "1">> />
+      &#32;
       <<tmap "splitAndSelect" ", " "2">>
     </$button>
   </$list>
 \end
 
 \define multi()
+\whitespace trim
   <$list filter="
       [[tmap:tm-delete-element, $:/core/images/delete-button, Delete selected nodes]]">
     <$button class="tc-btn-invisible">
       <$action-sendmessage $message=<<tmap "splitAndSelect" ", " "0">> />
       <$transclude tiddler=<<tmap "splitAndSelect" ", " "1">> />
+      &#32;
       <<tmap "splitAndSelect" ", " "2">>
     </$button>
   </$list>
 \end
+
+\whitespace trim
 
 <div class="tc-drop-down">
   <$macrocall $name=<<mode>> />

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/misc.editor_bar.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/misc.editor_bar.tid
@@ -1,5 +1,6 @@
 title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
 
+\whitespace trim
 \rules except wikilink
 \define showEdgeField() show-$(curEdgeId)$
 
@@ -7,6 +8,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
 
 <div class="tmap-menu-bar">
   View:
+  &#32;
   <$reveal type="match" text="false" default=<<isViewBound>> >
     <$select
         tiddler=<<viewHolder>>
@@ -22,6 +24,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
   <$reveal type="match" text="true" default=<<isViewBound>> >
     <b><<viewLabel>></b>
   </$reveal>
+  &#32;
 
 <!-- === Menu =================================================== -->
 
@@ -30,44 +33,46 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
       class="tmap-unicode-button"
       tooltip="Open the Menu">{{$:/core/images/menu-button}}
   </$button>
+  &#32;
 
   <$reveal type="popup" position="below" state=<<qualify "$:/temp/menu">> >
     <div class="tc-drop-down">
       <a href="http://tiddlymap.org#Documentation" target="_blank">
-        {{$:/core/images/info-button}} Open online help
+        {{$:/core/images/info-button}}&#32;Open online help
       </a>
       <$button class="tc-btn-invisible" message="tmap:tm-create-view">
-        {{$:/core/images/new-button}} Create new view
+        {{$:/core/images/new-button}}&#32;Create new view
       </$button>
       <$button class="tc-btn-invisible" message="tmap:tm-generate-widget">
-        {{$:/core/images/permalink-button}} Grab widget code
+        {{$:/core/images/permalink-button}}&#32;Grab widget code
       </$button>
       <div class="tmap-list-separator">Global configurations:</div>
       <$button class="tc-btn-invisible" message="tmap:tm-configure-system">
-        {{$:/core/images/options-button}} Configure TiddlyMap
+        {{$:/core/images/options-button}}&#32;Configure TiddlyMap
       </$button>
       <$button class="tc-btn-invisible" message="tmap:tm-manage-edge-types">
-        <span class="tmap-unicode-icon">◭</span> Manage edge-types
+        <span class="tmap-unicode-icon">◭</span>&#32;Manage edge-types
       </$button>
       <$button class="tc-btn-invisible" message="tmap:tm-manage-node-types">
-        <span class="tmap-unicode-icon">▢</span> Manage node-types
+        <span class="tmap-unicode-icon">▢</span>&#32;Manage node-types
       </$button>
       <div class="tmap-view-actions">
         <div class="tmap-list-separator">Actions for this view:</div>
         <$button class="tc-btn-invisible" message="tmap:tm-edit-view">
-          {{$:/core/images/options-button}} Configure view
+          {{$:/core/images/options-button}}&#32;Configure view
         </$button>
         <$button class="tc-btn-invisible" message="tmap:tm-rename-view">
-          {{$:/core/images/tag-button}} Rename view
+          {{$:/core/images/tag-button}}&#32;Rename view
         </$button>
         <$button class="tc-btn-invisible" message="tmap:tm-delete-view">
-          {{$:/core/images/delete-button}} Delete view
+          {{$:/core/images/delete-button}}&#32;Delete view
         </$button>
       </div>
     </div>
   </$reveal>
 
 <!-- === Neighbourhood menu ===================================== -->
+  &#32;
 
   <$reveal
       type="match"
@@ -110,19 +115,20 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
 
       <div class="tmap-list-separator">Neighbourhood traversal</div>
 
-      <$radio field="config.neighbourhood_directions" value="in"> Incoming</$radio><br />
-      <$radio field="config.neighbourhood_directions" value="out"> Outgoing</$radio><br />
-      <$radio field="config.neighbourhood_directions" value=""> Both</$radio>
+      <$radio field="config.neighbourhood_directions" value="in">&#32;Incoming</$radio><br />
+      <$radio field="config.neighbourhood_directions" value="out">&#32;Outgoing</$radio><br />
+      <$radio field="config.neighbourhood_directions" value="">&#32;Both</$radio>
 
       <div class="tmap-list-separator">Other</div>
 
       <$checkbox field="config.show_inter_neighbour_edges"
-          checked="true" unchecked="false"> Inter-neighbour edges</$checkbox>
+          checked="true" unchecked="false">&#32;Inter-neighbour edges</$checkbox>
 
     </div>
   </$reveal>
 
 <!-- === Tracing ===================================== -->
+  &#32;
 
   <$reveal
       type="match"
@@ -139,7 +145,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
   <$reveal type="popup" position="below" state=<<qualify "$:/temp/tmap-tracing">> >
     <div class="tc-drop-down">
       <$button message="tmap:tm-neighbourhood-reset-trace">
-        {{$:/core/images/erase}} Restart
+        {{$:/core/images/erase}}&#32;Restart
       </$button>
       <span
         title="
@@ -151,7 +157,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
           field="config.neighbourhood_trace_clicks"
           checked="true"
           unchecked="false"
-        >
+        >&#32;
           Trace clicked nodes
         </$checkbox>
       </span>
@@ -161,19 +167,20 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
           field="config.neighbourhood_focus_newly_traced_node"
           checked="true"
           unchecked="false"
-        >
+        >&#32;
           Focus traced nodes
         </$checkbox>
       </span>
       <br />
       <span title="Per default, only neighbours of nodes matching the node filter are displayed. Enable this option to also show neighbours of traced nodes.">
         <$checkbox field="config.neighbourhood_include_traced_node_neighbours"
-            checked="true" unchecked="false"> Show neighbours of all traced nodes</$checkbox>
+            checked="true" unchecked="false">&#32;Show neighbours of all traced nodes</$checkbox>
       </span>
     </div>
   </$reveal>
 
 <!-- === Export menu ============================================ -->
+&#32;
 
   <$reveal
       type="match"
@@ -190,7 +197,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
         class="tc-btn-invisible"
         tooltip="Export the graph and all its elements
                  in form of a JSON file">
-        {{$:/core/images/permalink-button}} Save as JSON file
+        {{$:/core/images/permalink-button}}&#32;Save as JSON file
       <$action-sendmessage
           $message="tmap:tm-download-graph"
           view=<<viewLabel>> />
@@ -199,13 +206,14 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/advancedEditorBar
         class="tc-btn-invisible"
         tooltip="Create a png image to download or save it
                  as image or view-placeholder in your wiki">
-        {{$:/core/images/palette}} Save as png image
+        {{$:/core/images/palette}}&#32;Save as png image
       <$action-sendmessage $message="tmap:tm-save-canvas" />
     </$button>
     </div>
   </$reveal>
 
 <!-- === Raster menu ============================================ -->
+  &#32;
 
   <$reveal
       type="match"

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/misc.focus_button.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/misc.focus_button.tid
@@ -4,6 +4,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/focusButton
 \define concat(str) $str$
 
 \define state() $(widgetPopupsPath)$/focus
+\whitespace trim
 
 <div class="tmap-focus-button">
   <$reveal type="match" state=<<state>> text="">
@@ -29,7 +30,8 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/focusButton
             type="text"
             tag="input"
             default="" />
-        <small><$count filter=<<filter>> /> results</small>
+        &#32;
+        <small><$count filter=<<filter>> />&#32;results</small>
         <hr />
         <div class="tmap-very-small-list">
           <$list filter=<<filter>>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/system.hook.sidebar_editor.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/editor/system.hook.sidebar_editor.tid
@@ -2,10 +2,12 @@ caption: Map
 tags: $:/tags/SideBar
 title: $:/plugins/felixhayashi/tiddlymap/hook/editor
 
+\whitespace trim
 \define width() calc(100% - 15px)
 
 <div class="tmap-mobile-editor">
   <div class="tmap-flash-message tmap-warning">
+    &#32;
     The editor is not displayed in mobile mode.
   </div>
 </div>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/livetab/system.hook.live_tab.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/livetab/system.hook.live_tab.tid
@@ -1,10 +1,12 @@
 title: $:/plugins/felixhayashi/tiddlymap/hook/liveTab
 caption: Live
 
+\whitespace trim
 \define width() calc(100% - 15px)
 
 <div class="tmap-mobile-editor">
   <div class="tmap-flash-message tmap-warning">
+    &#32;
     The live tab is not displayed in mobile mode.
   </div>
 </div>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/toolbar/system.hook.quick_connect_button.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/gui/toolbar/system.hook.quick_connect_button.tid
@@ -22,6 +22,7 @@ caption: {{$:/plugins/felixhayashi/tiddlymap/icon}} {{$:/language/Buttons/Tiddly
 \end
 
 \define showButton(state)
+\whitespace trim
 <$button set="$:/temp/tmap/state/popup/quickConnect"
          setTo="$state$" tooltip={{$:/language/Buttons/TiddlyMap/Hint}} 
          aria-label={{$:/language/Buttons/TiddlyMap/Caption}}
@@ -34,6 +35,7 @@ caption: {{$:/plugins/felixhayashi/tiddlymap/icon}} {{$:/language/Buttons/Tiddly
 \end
 
 \define searchResults()
+\whitespace trim
 <td>
   <$button tooltip="Create incoming edge">
     <<tmap "option" "misc.arrows.in">>
@@ -70,6 +72,7 @@ caption: {{$:/plugins/felixhayashi/tiddlymap/icon}} {{$:/language/Buttons/Tiddly
 \end
 
 \define showPopup()
+\whitespace trim
 <$set name="additional-classes" value="tmap-active-button">
   <$macrocall $name="showButton" state="" />
 </$set>
@@ -91,6 +94,7 @@ caption: {{$:/plugins/felixhayashi/tiddlymap/icon}} {{$:/language/Buttons/Tiddly
               type="text"
               tag="input"
               default="" />
+          &#32;
           <$select tiddler="$:/temp/quickConnectSearch/type" default="">
             <option></option>
             <$list filter=<<tmap "option" "selector.allEdgeTypesById">>>
@@ -103,15 +107,16 @@ caption: {{$:/plugins/felixhayashi/tiddlymap/icon}} {{$:/language/Buttons/Tiddly
         <td>Search:</td>
         <td>
           <$edit-text tiddler="$:/temp/quickConnectSearch" type="text" tag="input" default=""></$edit-text>
+          &#32;
           <$checkbox
               tiddler="$:/state/tmap/tid-toolbar"
               field="re-filter"
               checked="1"
               unchecked=""
-              default=""> regexp
+              default="">&#32;regexp
           </$checkbox>
 <!--
-          <small>(<$count filter=<<searchFilter>> /> results)</small>
+          <small>(<$count filter=<<searchFilter>> />&#32;results)</small>
 -->
         </td>
       </tr>
@@ -144,12 +149,13 @@ caption: {{$:/plugins/felixhayashi/tiddlymap/icon}} {{$:/language/Buttons/Tiddly
           <option value="in">incoming</option>
           <option value="out">outgoing</option>
       </$select>
+      &#32;
       <$checkbox
           tiddler="$:/state/tmap/tid-toolbar"
           field="filter.links"
           checked="-[[tw-body:link]]"
           unchecked=""
-          default=""> hide links
+          default="">&#32;hide links
       </$checkbox>
     </div>
     <table class="tmap-connection-table">

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/media/icon.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/media/icon.tid
@@ -1,13 +1,9 @@
 tags: $:/tags/Image
 title: $:/plugins/felixhayashi/tiddlymap/icon
 
+\whitespace trim
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    class="tc-image-tiddlymap-button tc-image-button"
    version="1.1"
    width="22pt"
@@ -39,24 +35,6 @@ title: $:/plugins/felixhayashi/tiddlymap/icon
          id="path3847"
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt" />
     </marker>
-    <inkscape:path-effect
-       effect="skeletal"
-       id="path-effect4329" />
-    <inkscape:path-effect
-       effect="skeletal"
-       id="path-effect4321" />
-    <inkscape:path-effect
-       effect="skeletal"
-       id="path-effect4315" />
-    <inkscape:path-effect
-       effect="skeletal"
-       id="path-effect4307" />
-    <inkscape:path-effect
-       effect="skeletal"
-       id="path-effect4299" />
-    <inkscape:path-effect
-       effect="skeletal"
-       id="path-effect4293" />
   </defs>
   <g
      transform="translate(0,-1024.5289)"
@@ -76,16 +54,4 @@ title: $:/plugins/felixhayashi/tiddlymap/icon
        id="path3004"
        style="fill-opacity:1;fill-rule:nonzero" />
   </g>
-  <metadata
-     id="metadata3772">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title></dc:title>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/src/plugins/felixhayashi/tiddlymap/tiddlers/misc/misc.macros.tid
+++ b/src/plugins/felixhayashi/tiddlymap/tiddlers/misc/misc.macros.tid
@@ -3,6 +3,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
 \define concat(str) $str$
 
 \define input-text(field, index, default, readonly, class, focus)
+\whitespace trim
   <$reveal type="match" text="" default="$readonly$">
     <$edit-text
         tiddler=<<output>>
@@ -20,6 +21,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
 \end
 
 \define input-button(field, index, default, default, label:"Proceed")
+\whitespace trim
   <div class="tmap-button-wrapper">
   <$button>$label$
     <$action-setfield $tiddler=<<output>> $field="$field$" index="$index$" $value="$default$" />
@@ -28,6 +30,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
 \end
 
 \define input-textarea(field, index, default, default, class, focus)
+\whitespace trim
   <$edit-text
       tiddler=<<output>>
       field="$field$"
@@ -41,6 +44,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
 \end
 
 \define input-checkbox(field, index, readonly, default)
+\whitespace trim
   <$reveal type="match" text="" default="$readonly$">
     <$checkbox
         tiddler=<<output>>
@@ -56,6 +60,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
 \end
 
 \define input-multi-checkbox(selectFilter, invert:"no", default)
+\whitespace trim
   <div class="tmap-no-stretch">
   <$list
       filter="$selectFilter$"
@@ -72,6 +77,7 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
 \end
 
 \define input-select(field, index, selectFilter, default, nochoice)
+\whitespace trim
   <$select
       tiddler=<<output>>
       field="$field$"
@@ -91,18 +97,21 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
 \end
 
 \define input-radio(field, index, selectFilter, default)
+\whitespace trim
   <$list filter="$selectFilter$">
     <$radio
         tiddler=<<output>>
         field="$field$"
         index="$index$"
         value=<<tmap "splitAndSelect" "|" "0">>>
+      &#32;
       <<tmap "splitAndSelect" "|" "1">>
     </$radio><br />
   </$list>
 \end
 
 \define tmap-row(title, field, index, type, descr, note, label, default, readonly, reset, selectFilter, nochoice, invert, class, focus)
+\whitespace trim
   <tr>
     <td class="tmap-title">$title$:</td>
     <td>
@@ -126,13 +135,14 @@ title: $:/plugins/felixhayashi/tiddlymap/misc/macros
     <td>
       <span class="tmap-description">$descr$</span>
       <$reveal type="nomatch" text="" default="$note$">
-        <div class="tmap-note">''Note:'' $note$</div>
+        <div class="tmap-note">''Note:''&#32;$note$</div>
       </$reveal>
     </td>
   </tr>
 \end
 
 \define visConfiguration(inheritedList, extensionField, styleName:"style")
+\whitespace trim
   <fieldset><legend>Visjs configurations ($styleName$)</legend>
     <div class="tmap-flash-message tmap-info">
       Only config items that you actually changed have an effect on


### PR DESCRIPTION
Added whitespace trim pragma where appropriate.

This will tighten up the parseTreeNode for tiddlymap's bits, which will make it a little more memory efficient and slightly faster. It also will make tiddlymap's wikitext compress better with TW5-Uglify.

This does, however, make tiddlymap depend on V5.1.15, since that is the version that \whitespace trim was added.