### PR TITLE
Sourcemap

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -83,7 +83,6 @@ import jsdoc from 'gulp-jsdoc3';
 import esprima from 'gulp-esprima';
 import debug from 'gulp-debug';
 import bump from 'gulp-bump';
-import sourcemaps from 'gulp-sourcemaps';
 
 /**** Preprocessing ************************************************/
 
@@ -207,16 +206,9 @@ gulp.task('compile and move scripts', () => {
     }
   };
 
-  const sourceMapOpts = {
-    destPath: outPath.maps,
-    sourceMappingURLPrefix: '.'
-  };
-
   return gulp.src(pluginSrc + '/**/*.js')
-    .pipe(sourcemaps.init())
     .pipe(babel())
     .pipe(gulpif (argv.production, terser(uglifyOpts)))
-    .pipe(sourcemaps.write('./maps', sourceMapOpts))
     .pipe(gulp.dest(outPath.dist));
 
 });

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "gulp-jsdoc3": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "gulp-sass": "^4.0.2",
-    "gulp-sourcemaps": "^2.6.5",
     "gulp-terser": "^1.2.0",
     "gulp-util": "^3.0.8",
     "ink-docstrap": "^1.3.0",


### PR DESCRIPTION
This removes the sourcemapping out of the build. Why? Because no one is using it, and the sourcemap tags inside all the javascript files are causing a bunch of warnings to pop up whenever you open the developer tools.

But why scrap the source mapping feature? Because only works if you are using a standalone TiddlyWiki, opened locally, with the "map" directory existing in the same directory as the TiddlyWiki file. The only person who has this setup is you, Felix. No one else.

Besides, now that TW-Uglify is out, it manages sourcemapping in a way that might actually be useful to end users. It also takes care of uglifying far better and more cleanly than gulp can, but I won't get into that right now.